### PR TITLE
fix: Correct TemplateSyntaxError in detalle_analisis.html

### DIFF
--- a/templates/analizador/detalle_analisis.html
+++ b/templates/analizador/detalle_analisis.html
@@ -80,7 +80,6 @@
         </div>
         <div class="card-body">
             {% if hallazgos %}
-            {% if hallazgos %}
                 {% regroup hallazgos by tipo as hallazgos_por_tipo %}
                 {% for grupo in hallazgos_por_tipo %}
                     <div class="mb-4">


### PR DESCRIPTION
I resolved a TemplateSyntaxError in `templates/analizador/detalle_analisis.html` caused by a missing `endif` for an `if hallazgos` block. The fix involved removing a redundant nested `if hallazgos` tag, allowing the existing `else` and `endif` tags to correctly close the intended outer block.